### PR TITLE
Fix order of arguments for row/col ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fltk-grid"
-version = "0.1.4"
+version = "1.0.0"
 edition = "2018"
 description = "A grid widget for fltk-rs"
 repository = "https://github.com/fltk-rs/fltk-grid"
@@ -11,4 +11,4 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-fltk = "1.3.15"
+fltk = "1.3.33"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A grid widget for fltk-rs.
 ```toml
 [dependencies]
 fltk = "1.3"
-fltk-grid = "0.1"
+fltk-grid = "1.0"
 ```
 
 Basically, the crate contains a single type Grid which has 4 main non-constructor methods:
@@ -28,7 +28,7 @@ fn main() {
     grid.debug(false); // set to true to show cell outlines and numbers
     grid.set_layout(5, 5); // 5 rows, 5 columns
     grid.insert(&mut button::Button::default(), 0, 1); // widget, row, col
-    grid.insert(&mut button::Button::default(), 2..5, 1..2); // widget, row range, col range
+    grid.insert(&mut button::Button::default(), 2..3, 1..4); // widget, row range, col range
     win.end();
     win.show();
     a.run().unwrap();

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -37,7 +37,7 @@ impl Form {
         title.set_label_color(enums::Color::White);
         grid.insert(
             // insert widgets
-            &mut title, 0..3, 1
+            &mut title, 0, 1..4
         );
         grid.insert(&mut frame::Frame::default().with_label("Name"), 2, 1);
         grid.insert(&mut self.name, 2, 3);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -8,7 +8,7 @@ fn main() {
     grid.debug(false); // set to true to show cell outlines and numbers
     grid.set_layout(5, 5); // 5 rows, 5 columns
     grid.insert(&mut button::Button::default(), 0, 1); // widget, row, col
-    grid.insert(&mut button::Button::default(), 2..5, 1..2); // widget, row range, col range
+    grid.insert(&mut button::Button::default(), 2..3, 1..4); // widget, row range, col range
     // or
     // grid.insert_ext(&mut button::Button::default(), 2, 1, 3, 1); // widget, row, col, row_span, col_span
     win.end();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl Grid {
     ) {
         let row = row.into();
         let col = col.into();
-        self.insert_ext(widget, row.start as _, col.start as _, row.len() as _, col.len() as _);
+        self.insert_ext(widget, row.start as _, col.start as _, col.len() as _, row.len() as _);
     }
 
     /// Removes a widget

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl Grid {
     pub fn remove<W: WidgetExt>(&mut self, widget: &W) {
         self.widgets
             .borrow_mut()
-            .retain(|_, v| unsafe { v.as_widget_ptr() != widget.as_widget_ptr() });
+            .retain(|_, v| v.as_widget_ptr() != widget.as_widget_ptr());
         self.table.remove(widget);
     }
 


### PR DESCRIPTION
I missed the part about possibly just removing the range API, nevertheless here is a patch.
This also removes a superfluous unsafe block.